### PR TITLE
change the toolbox call convention

### DIFF
--- a/src/com/redhat/Application.groovy
+++ b/src/com/redhat/Application.groovy
@@ -7,9 +7,10 @@ class Application {
     String name
     String description
     String plan
-    String service
-    boolean  resume= false
-    boolean suspend= false
+    // Disabled for now because of https://issues.jboss.org/browse/THREESCALE-2844
+    // boolean active = true
     String userkey
+    String clientId
+    String clientSecret
 
 }

--- a/src/com/redhat/OpenAPI2.groovy
+++ b/src/com/redhat/OpenAPI2.groovy
@@ -2,11 +2,22 @@
 
 package com.redhat
 
+enum ThreescaleSecurityScheme {
+  OPEN,
+  APIKEY,
+  OIDC;
+
+  // Avoid Jenkins sandbox restriction on java.util.LinkedHashMap
+  // by providing an empty constructor
+  public ThreescaleSecurityScheme() {}
+}
+
 class OpenAPI2 {
     String filename
     def content
     String version
     String majorVersion
+    ThreescaleSecurityScheme securityScheme
 
     OpenAPI2(Map conf) {
         assert conf.filename != null
@@ -19,5 +30,41 @@ class OpenAPI2 {
         this.version = content.info.version
         assert this.version != null
         this.majorVersion = version.tokenize(".")[0]
+
+        String securitySchemeName = null
+        if (content.security != null && content.security.size() == 1) {
+            Set securitySchemes = content.security[0].keySet()
+            if (securitySchemes.size() == 1) {
+                securitySchemeName = securitySchemes.first()
+            } else {
+                throw new Exception("Cannot handle OpenAPI Specifications with multiple security requirements or no global requirement. Found ${content.security.size()}/${securitySchemes.size()} security requirements.")
+            }
+
+        } else if ((content.security == null || content.security.size() == 0)
+                && (content.securityDefinitions == null || content.securityDefinitions.size() == 0)) {
+
+            // To make it explicit that this is an Open API, we require no security requirement
+            // and no security definition (better be safe than sorry...)
+            this.securityScheme = ThreescaleSecurityScheme.OPEN
+        } else {
+            throw new Exception("Cannot handle OpenAPI Specifications with multiple security requirements or no global requirement. Found ${content.security != null ? content.security.size() : "no"} security requirements.")
+        }
+
+        if (securitySchemeName != null && content.securityDefinitions != null
+            && content.securityDefinitions.get(securitySchemeName) != null) {
+
+            Map securityScheme = content.securityDefinitions.get(securitySchemeName)
+            String securityType = securityScheme.type
+
+            if (securityType == "oauth2") {
+                this.securityScheme = ThreescaleSecurityScheme.OIDC
+            } else if (securityType == "apiKey") {
+                this.securityScheme = ThreescaleSecurityScheme.APIKEY
+            } else {
+                throw new Exception("Cannot handle OpenAPI Specifications with security scheme: ${securityType}")
+            }
+        } else {
+            throw new Exception("Cannot find security scheme ${securitySchemeName} in OpenAPI Specifications")
+        }
     }
 }

--- a/src/com/redhat/Toolbox.groovy
+++ b/src/com/redhat/Toolbox.groovy
@@ -45,10 +45,16 @@ def runToolbox(ToolboxConfiguration conf, Map call) {
                   "name": "job",
                   "image": conf.image,
                   "imagePullPolicy": conf.imagePullPolicy,
-                  "command": [ "scl", "enable", "rh-ruby25", "/opt/rh/rh-ruby25/root/usr/local/bin/${call.commandLine}" ],
+                  "args": call.commandLine,
+                  "env": [
+                    [
+                      "name": "HOME",
+                      "value": "/config"
+                    ]
+                  ],
                   "volumeMounts": [
                     [
-                      "mountPath": "/opt/app-root/src/",
+                      "mountPath": "/config",
                       "name": "toolbox-config"
                     ],
                     [

--- a/src/com/redhat/ToolboxConfiguration.groovy
+++ b/src/com/redhat/ToolboxConfiguration.groovy
@@ -22,18 +22,18 @@ class ToolboxConfiguration {
 
   String getToolboxVersion() {
     def result = toolbox.runToolbox(this,
-                                    [ commandLine: "3scale -v",
+                                    [ commandLine: [ "3scale", "-v" ],
                                       jobName: "version" ])
     return result.stdout
   }
 
-  String getGlobalToolboxOptions() {
-      def options = ""
+  List<String> getGlobalToolboxOptions() {
+      List<String> options = []
       if (this.insecure) {
-          options += "-k "
+          options += "-k"
       }
       if (this.verbose) {
-          options += "--verbose "
+          options += "--verbose"
       }
       return options
   }


### PR DESCRIPTION
To prevent issues with shell variable interpolation and string quoting, I changed the calling convention: using a string array instead of a big string. 
