### PR TITLE
Add new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Add a stage to run your integration tests:
     sh """set -e +x
     curl -f -w "ListBeers: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer -H 'api-key: ${service.applications[0].userkey}'
     curl -f -w "GetBeer: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer/Weissbier -H 'api-key: ${service.applications[0].userkey}'
-    curl -f -w "GetBeer: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer/findByStatus/available -H 'api-key: ${service.applications[0].userkey}'
+    curl -f -w "FindBeersByStatus: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer/findByStatus/available -H 'api-key: ${service.applications[0].userkey}'
     """
   }
 ```

--- a/README.md
+++ b/README.md
@@ -83,16 +83,7 @@ Add a stage to create the Application Plans:
 Add a global variable and a stage to create the test Application:
 
 ```groovy
-def testApplicationCredentials = null
-
-[...]
-
   stage("Create an Application") {
-    // Patch the test application with default credentials
-    testApplicationCredentials = toolbox.getDefaultApplicationCredentials(service, service.applications[0].name)
-    service.applications[0].setUserkey(testApplicationCredentials.userKey)
-    service.applications[0].setClientId(testApplicationCredentials.clientId)
-    service.applications[0].setClientSecret(testApplicationCredentials.clientSecret)
     service.applyApplication()
   }
 ```
@@ -105,9 +96,9 @@ Add a stage to run your integration tests:
     // to fetch the proxy definition to extract the staging public url
     def proxy = service.readProxy("sandbox")
     sh """set -e +x
-    curl -f -w "ListBeers: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer -H 'api-key: ${testApplicationCredentials.userKey}'
-    curl -f -w "GetBeer: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer/Weissbier -H 'api-key: ${testApplicationCredentials.userKey}'
-    curl -f -w "GetBeer: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer/findByStatus/available -H 'api-key: ${testApplicationCredentials.userKey}'
+    curl -f -w "ListBeers: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer -H 'api-key: ${service.applications[0].userkey}'
+    curl -f -w "GetBeer: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer/Weissbier -H 'api-key: ${service.applications[0].userkey}'
+    curl -f -w "GetBeer: %{http_code}\n" -o /dev/null -s ${proxy.sandbox_endpoint}/api/beer/findByStatus/available -H 'api-key: ${service.applications[0].userkey}'
     """
   }
 ```

--- a/src/com/redhat/OpenAPI2.groovy
+++ b/src/com/redhat/OpenAPI2.groovy
@@ -51,21 +51,23 @@ class OpenAPI2 {
             throw new Exception("Cannot handle OpenAPI Specifications with multiple security requirements or no global requirement. Found ${content.security != null ? content.security.size() : "no"} security requirements.")
         }
 
-        if (securitySchemeName != null && content.securityDefinitions != null
-            && content.securityDefinitions.get(securitySchemeName) != null) {
+        if (securitySchemeName != null) {
+            if (content.securityDefinitions != null
+             && content.securityDefinitions.get(securitySchemeName) != null) {
 
-            Map securityScheme = content.securityDefinitions.get(securitySchemeName)
-            String securityType = securityScheme.type
+                Map securityScheme = content.securityDefinitions.get(securitySchemeName)
+                String securityType = securityScheme.type
 
-            if (securityType == "oauth2") {
-                this.securityScheme = ThreescaleSecurityScheme.OIDC
-            } else if (securityType == "apiKey") {
-                this.securityScheme = ThreescaleSecurityScheme.APIKEY
+                if (securityType == "oauth2") {
+                    this.securityScheme = ThreescaleSecurityScheme.OIDC
+                } else if (securityType == "apiKey") {
+                    this.securityScheme = ThreescaleSecurityScheme.APIKEY
+                } else {
+                    throw new Exception("Cannot handle OpenAPI Specifications with security scheme: ${securityType}")
+                }
             } else {
-                throw new Exception("Cannot handle OpenAPI Specifications with security scheme: ${securityType}")
+                throw new Exception("Cannot find security scheme ${securitySchemeName} in OpenAPI Specifications")
             }
-        } else {
-            throw new Exception("Cannot find security scheme ${securitySchemeName} in OpenAPI Specifications")
-        }
+        } // else: this is an Open API
     }
 }

--- a/src/com/redhat/OpenAPI2.groovy
+++ b/src/com/redhat/OpenAPI2.groovy
@@ -18,6 +18,7 @@ class OpenAPI2 {
     String version
     String majorVersion
     ThreescaleSecurityScheme securityScheme
+    boolean validateOAS = true
 
     OpenAPI2(Map conf) {
         assert conf.filename != null

--- a/src/com/redhat/ThreescaleEnvironment.groovy
+++ b/src/com/redhat/ThreescaleEnvironment.groovy
@@ -12,5 +12,7 @@ class ThreescaleEnvironment {
   String oidcIssuerEndpoint
   String publicStagingWildcardDomain
   String publicProductionWildcardDomain
+  String privateBasePath
+  String publicBasePath
 }
 

--- a/src/com/redhat/ThreescaleEnvironment.groovy
+++ b/src/com/redhat/ThreescaleEnvironment.groovy
@@ -10,5 +10,7 @@ class ThreescaleEnvironment {
   String productionPublicBaseURL
   String privateBaseUrl
   String oidcIssuerEndpoint
+  String publicStagingWildcardDomain
+  String publicProductionWildcardDomain
 }
 

--- a/src/com/redhat/ThreescaleEnvironment.groovy
+++ b/src/com/redhat/ThreescaleEnvironment.groovy
@@ -9,5 +9,6 @@ class ThreescaleEnvironment {
   String stagingPublicBaseURL
   String productionPublicBaseURL
   String privateBaseUrl
+  String oidcIssuerEndpoint
 }
 

--- a/src/com/redhat/ThreescaleService.groovy
+++ b/src/com/redhat/ThreescaleService.groovy
@@ -12,10 +12,6 @@ class ThreescaleService {
     void importOpenAPI() {
         Util util = new Util()
 
-
-        // Compute the target system_name
-        this.environment.targetSystemName = (this.environment.environmentName != null ? "${this.environment.environmentName}_" : "") + this.environment.baseSystemName + "_${this.openapi.majorVersion}"
-
         def baseName = basename(this.openapi.filename)
         def globalOptions = toolbox.getGlobalToolboxOptions()
         def commandLine = [ "3scale", "import", "openapi" ] + globalOptions + [ "-t", this.environment.targetSystemName, "-d", this.toolbox.destination, "/artifacts/${baseName}" ]
@@ -27,6 +23,18 @@ class ThreescaleService {
         }
         if (this.environment.privateBaseUrl != null) {
             commandLine += "--override-private-base-url=${this.environment.privateBaseUrl}"
+        }
+
+        if (this.openapi.securityScheme == ThreescaleSecurityScheme.OPEN) {
+            commandLine += "--default-credentials-userkey=${this.applications[0].userkey}"
+        }
+
+        if (this.openapi.securityScheme == ThreescaleSecurityScheme.OIDC) {
+            commandLine += "--oidc-issuer-endpoint=${this.environment.oidcIssuerEndpoint}"
+        }
+
+        if (! this.openapi.validateOAS) {
+            commandLine += "--skip-openapi-validation"
         }
 
         toolbox.runToolbox(commandLine: commandLine,

--- a/src/com/redhat/ThreescaleService.groovy
+++ b/src/com/redhat/ThreescaleService.groovy
@@ -33,6 +33,14 @@ class ThreescaleService {
             commandLine += "--oidc-issuer-endpoint=${this.environment.oidcIssuerEndpoint}"
         }
 
+        if (this.environment.privateBasePath != null) {
+            commandLine += "--override-private-basepath=${this.environment.privateBasePath}"
+        }
+
+        if (this.environment.publicBasePath != null) {
+            commandLine += "--override-public-basepath=${this.environment.publicBasePath}"
+        }
+
         if (! this.openapi.validateOAS) {
             commandLine += "--skip-openapi-validation"
         }

--- a/src/com/redhat/Toolbox.groovy
+++ b/src/com/redhat/Toolbox.groovy
@@ -23,15 +23,19 @@ def runToolbox(ToolboxConfiguration conf, Map call) {
         createConfigMap(openshift, oasConfigMapName, [ (call.openAPI.filename): call.openAPI.content ])
       }
 
-      def jobName = "${JOB_BASE_NAME}-${BUILD_NUMBER}-${call.jobName}"
+      // Job name and labels are limited to 63 characters and cannot end with a dash (-)
+      def jobName = "${JOB_BASE_NAME}-${BUILD_NUMBER}-${call.jobName}".take(63)
+      while (jobName[-1] == "-") {
+        jobName = jobName[0..-2] // Strip last character if it's a dash
+      }
       def jobSpecs = [
         "apiVersion": "batch/v1",
         "kind": "Job",
         "metadata": [
           "name": jobName,
           "labels": [
-            "build": "${JOB_BASE_NAME}-${BUILD_NUMBER}",
-            "job": "${JOB_BASE_NAME}"
+            "build": "${JOB_BASE_NAME}-${BUILD_NUMBER}".take(63),
+            "job": "${JOB_BASE_NAME}".take(63)
           ]
         ],
         "spec": [

--- a/vars/toolbox.groovy
+++ b/vars/toolbox.groovy
@@ -34,6 +34,15 @@ ThreescaleService prepareThreescaleService(Map conf) {
     conf.environment.targetSystemName = (conf.environment.environmentName != null ? "${conf.environment.environmentName}_" : "") + conf.environment.baseSystemName + "_${openapi.majorVersion}"
   }
 
+  // compute the public base urls from system_name, version number and wildcard domain (for semantic versioning)
+  String apiBaseName = conf.environment.targetSystemName.replaceAll(/[^-0-9a-zA-Z]/, "-").toLowerCase()
+  if (conf.environment.stagingPublicBaseURL == null && conf.environment.publicStagingWildcardDomain != null) {
+    conf.environment.stagingPublicBaseURL = "https://${apiBaseName}.${conf.environment.publicStagingWildcardDomain}"
+  }
+  if (conf.environment.productionPublicBaseURL == null && conf.environment.publicProductionWildcardDomain != null) {
+    conf.environment.productionPublicBaseURL = "https://${apiBaseName}.${conf.environment.publicProductionWildcardDomain}"
+  }
+
   ThreescaleEnvironment environment = new ThreescaleEnvironment(conf.environment)
   ToolboxConfiguration toolbox = new ToolboxConfiguration(conf.toolbox + ["JOB_BASE_NAME": JOB_BASE_NAME, "BUILD_NUMBER": BUILD_NUMBER])
 


### PR DESCRIPTION
- apply default app credentials as part of the toolbox.prepareThreescaleService call (if none have been given)
- compute the public base urls from system_name, version number and wildcard domain (semantic versioning)
- fix an exception with the "open" security scheme handling
- implement public/private base path override
- limit job name to 63 chars