### PR TITLE
handle multi-environment

### DIFF
--- a/src/com/redhat/OpenAPI2.groovy
+++ b/src/com/redhat/OpenAPI2.groovy
@@ -25,6 +25,22 @@ class OpenAPI2 {
         this.filename = conf.filename
     }
 
+    String getUpdatedContent() {
+        Util util = new Util()
+        String baseName = "updated-" + util.basename(this.filename)
+        util.removeFile(baseName)
+        util.writeOpenAPISpecificationFile(baseName, this.content)
+        return util.readFile(baseName)
+    }
+
+    void updateTitleWithEnvironmentAndVersion(String environmentName) {
+        if (environmentName != null) {
+            this.content.info.title = "${this.content.info.title} (${environmentName.toUpperCase()}, v${this.version})"
+        } else {
+            this.content.info.title = "${this.content.info.title} (v${this.version})"
+        }
+    }
+
     void parseOpenAPISpecificationFile() {
         this.content = new Util().readOpenAPISpecificationFile(this.filename)
         assert content.swagger == "2.0"

--- a/src/com/redhat/ThreescaleService.groovy
+++ b/src/com/redhat/ThreescaleService.groovy
@@ -12,7 +12,7 @@ class ThreescaleService {
     void importOpenAPI() {
         Util util = new Util()
 
-        def baseName = basename(this.openapi.filename)
+        def baseName = util.basename(this.openapi.filename)
         def globalOptions = toolbox.getGlobalToolboxOptions()
         def commandLine = [ "3scale", "import", "openapi" ] + globalOptions + [ "-t", this.environment.targetSystemName, "-d", this.toolbox.destination, "/artifacts/${baseName}" ]
         if (this.environment.stagingPublicBaseURL != null) {
@@ -49,7 +49,7 @@ class ThreescaleService {
                 jobName: "import",
                 openAPI: [
                         "filename": baseName,
-                        "content" : util.readFile(this.openapi.filename)
+                        "content" : this.openapi.getUpdatedContent()
                 ])
     }
 
@@ -127,12 +127,6 @@ class ThreescaleService {
         def commandLine = [ "3scale", "proxy-config", "promote" ] + globalOptions + [ this.toolbox.destination, this.environment.targetSystemName ]
         toolbox.runToolbox(commandLine: commandLine,
                 jobName: "apply-proxy-config-promote")
-    }
-
-    static String basename(path) {
-        def filename = path.drop(path.lastIndexOf("/") != -1 ? path.lastIndexOf("/") + 1 : 0)
-        filename = filename.replaceAll("[^-._a-zA-Z0-9]", "_")
-        return filename
     }
 
 }

--- a/src/com/redhat/Util.groovy
+++ b/src/com/redhat/Util.groovy
@@ -21,6 +21,26 @@ def readFile(String filename) {
     return readFile(file: filename)
 }
 
+def removeFile(String filename) {
+    sh "rm -f -- '$filename'"
+}
+
+String basename(path) {
+    def filename = path.drop(path.lastIndexOf("/") != -1 ? path.lastIndexOf("/") + 1 : 0)
+    filename = filename.replaceAll("[^-._a-zA-Z0-9]", "_")
+    return filename
+}
+
+def writeOpenAPISpecificationFile(String fileName, def content) {
+    if (fileName.toLowerCase().endsWith(".json")) {
+        return writeJSON(file: fileName, json: content)
+    } else if (fileName.toLowerCase().endsWith(".yaml") || fileName.toLowerCase().endsWith(".yml")) {
+        return writeYaml(file: fileName, data: content)
+    } else {
+        throw new Exception("Can't decide between JSON and YAML on ${fileName}")
+    }
+}
+
 def readJSON(String json) {
     return readJSON(text: json)
 }

--- a/vars/toolbox.groovy
+++ b/vars/toolbox.groovy
@@ -28,6 +28,7 @@ ThreescaleService prepareThreescaleService(Map conf) {
 
   OpenAPI2 openapi = new OpenAPI2(conf.openapi)
   openapi.parseOpenAPISpecificationFile()
+  openapi.updateTitleWithEnvironmentAndVersion(conf.environment.environmentName)
 
   if (conf.environment.targetSystemName == null) {
     // Compute the target system_name


### PR DESCRIPTION
- Update the "info.title" field of the OpenAPI Specification file to add the version number and the environment name
- move the `basename` function to `Util`

