### PR TITLE
Update ToolboxConfiguration.groovy to target newer 3scale toolbox image

### DIFF
--- a/src/com/redhat/ToolboxConfiguration.groovy
+++ b/src/com/redhat/ToolboxConfiguration.groovy
@@ -6,7 +6,7 @@ class ToolboxConfiguration {
   String openshiftProject
   String destination
   String secretName
-  String image = "quay.io/redhat/3scale-toolbox:v0.11.0"
+  String image = "quay.io/redhat/3scale-toolbox:v0.14.0"
   int backoffLimit = 2 // three attempts (one first try + two retries)
   String imagePullPolicy = "IfNotPresent"
   int activeDeadlineSeconds = 90


### PR DESCRIPTION
I was receiving a build failure `openapi: unrecognised option -- override-private-base-url`. Updating the CLI version fixes it. 

Should a new toolbox release automatically trigger a new release of this plugin so users can pin a toolbox version and/or stay current?