### PR TITLE
OpenAPI 3 support

### DIFF
--- a/src/com/redhat/OpenAPI.groovy
+++ b/src/com/redhat/OpenAPI.groovy
@@ -1,0 +1,9 @@
+#!groovy
+
+package com.redhat
+
+interface OpenAPI {
+    String getUpdatedContent()
+    void updateTitleWithEnvironmentAndVersion(String environmentName)
+    void parseOpenAPISpecificationFile()
+}

--- a/src/com/redhat/OpenAPI.groovy
+++ b/src/com/redhat/OpenAPI.groovy
@@ -2,8 +2,40 @@
 
 package com.redhat
 
-interface OpenAPI {
-    String getUpdatedContent()
-    void updateTitleWithEnvironmentAndVersion(String environmentName)
-    void parseOpenAPISpecificationFile()
+abstract class OpenAPI {
+    String filename
+    def content
+    String version
+    String majorVersion
+    ThreescaleSecurityScheme securityScheme
+    boolean validateOAS = true
+
+    OpenAPI(Map conf) {
+        assert conf.filename != null
+        assert conf.content != null
+        this.filename = conf.filename
+        this.content = conf.content
+    }
+
+    String getUpdatedContent() {
+        Util util = new Util()
+        String baseName = "updated-" + util.basename(this.filename)
+        util.removeFile(baseName)
+        util.writeOpenAPISpecificationFile(baseName, this.content)
+        return util.readFile(baseName)
+    }
+
+    void updateTitleWithEnvironmentAndVersion(String environmentName) {
+        String title = this.content.info.title as String
+        String version = this.version as String
+        String newTitle = null
+        if (environmentName != null) {
+            newTitle = "${title} (${environmentName.toUpperCase()}, v${version})"
+        } else {
+            newTitle = "${title} (v${version})"
+        }
+        this.content.info.title = newTitle
+    }
+    
+    abstract void parseOpenAPISpecificationFile()
 }

--- a/src/com/redhat/OpenAPI2.groovy
+++ b/src/com/redhat/OpenAPI2.groovy
@@ -2,39 +2,9 @@
 
 package com.redhat
 
-class OpenAPI2 implements OpenAPI {
-    String filename
-    def content
-    String version
-    String majorVersion
-    ThreescaleSecurityScheme securityScheme
-    boolean validateOAS = true
-
+class OpenAPI2 extends OpenAPI {
     OpenAPI2(Map conf) {
-        assert conf.filename != null
-        assert conf.content != null
-        this.filename = conf.filename
-        this.content = conf.content
-    }
-
-    String getUpdatedContent() {
-        Util util = new Util()
-        String baseName = "updated-" + util.basename(this.filename)
-        util.removeFile(baseName)
-        util.writeOpenAPISpecificationFile(baseName, this.content)
-        return util.readFile(baseName)
-    }
-
-    void updateTitleWithEnvironmentAndVersion(String environmentName) {
-        String title = this.content.info.title as String
-        String version = this.version as String
-        String newTitle = null
-        if (environmentName != null) {
-            newTitle = "${title} (${environmentName.toUpperCase()}, v${version})"
-        } else {
-            newTitle = "${title} (v${version})"
-        }
-        this.content.info.title = newTitle
+        super(conf);
     }
 
     void parseOpenAPISpecificationFile() {

--- a/src/com/redhat/OpenAPI3.groovy
+++ b/src/com/redhat/OpenAPI3.groovy
@@ -2,39 +2,9 @@
 
 package com.redhat
 
-class OpenAPI3 implements OpenAPI {
-    String filename
-    def content
-    String version
-    String majorVersion
-    ThreescaleSecurityScheme securityScheme
-    boolean validateOAS = true
-
+class OpenAPI3 extends OpenAPI {
     OpenAPI3(Map conf) {
-        assert conf.filename != null
-        assert conf.content != null
-        this.filename = conf.filename
-        this.content = conf.content
-    }
-
-    String getUpdatedContent() {
-        Util util = new Util()
-        String baseName = "updated-" + util.basename(this.filename)
-        util.removeFile(baseName)
-        util.writeOpenAPISpecificationFile(baseName, this.content)
-        return util.readFile(baseName)
-    }
-
-    void updateTitleWithEnvironmentAndVersion(String environmentName) {
-        String title = this.content.info.title as String
-        String version = this.version as String
-        String newTitle = null
-        if (environmentName != null) {
-            newTitle = "${title} (${environmentName.toUpperCase()}, v${version})"
-        } else {
-            newTitle = "${title} (v${version})"
-        }
-        this.content.info.title = newTitle
+        super(conf);
     }
 
     void parseOpenAPISpecificationFile() {

--- a/src/com/redhat/OpenAPI3.groovy
+++ b/src/com/redhat/OpenAPI3.groovy
@@ -2,7 +2,7 @@
 
 package com.redhat
 
-class OpenAPI2 implements OpenAPI {
+class OpenAPI3 implements OpenAPI {
     String filename
     def content
     String version
@@ -10,7 +10,7 @@ class OpenAPI2 implements OpenAPI {
     ThreescaleSecurityScheme securityScheme
     boolean validateOAS = true
 
-    OpenAPI2(Map conf) {
+    OpenAPI3(Map conf) {
         assert conf.filename != null
         assert conf.content != null
         this.filename = conf.filename
@@ -38,12 +38,14 @@ class OpenAPI2 implements OpenAPI {
     }
 
     void parseOpenAPISpecificationFile() {
-        assert content.swagger == "2.0"
+        assert content.openapi != null
+        assert content.openapi.startsWith("3.0")
         this.version = content.info.version
         assert this.version != null
         this.majorVersion = version.tokenize(".")[0]
 
         String securitySchemeName = null
+        def securityDefinitions = content.components?.securitySchemes
         if (content.security != null && content.security.size() == 1) {
             Set securitySchemes = content.security[0].keySet()
             if (securitySchemes.size() == 1) {
@@ -53,7 +55,7 @@ class OpenAPI2 implements OpenAPI {
             }
 
         } else if ((content.security == null || content.security.size() == 0)
-                && (content.securityDefinitions == null || content.securityDefinitions.size() == 0)) {
+                && (securityDefinitions == null || securityDefinitions.size() == 0)) {
 
             // To make it explicit that this is an Open API, we require no security requirement
             // and no security definition (better be safe than sorry...)
@@ -63,10 +65,10 @@ class OpenAPI2 implements OpenAPI {
         }
 
         if (securitySchemeName != null) {
-            if (content.securityDefinitions != null
-             && content.securityDefinitions.get(securitySchemeName) != null) {
+            if (securityDefinitions != null
+             && securityDefinitions.get(securitySchemeName) != null) {
 
-                Map securityScheme = content.securityDefinitions.get(securitySchemeName)
+                Map securityScheme = securityDefinitions.get(securitySchemeName)
                 String securityType = securityScheme.type
 
                 if (securityType == "oauth2") {

--- a/src/com/redhat/ThreescaleSecurityScheme.groovy
+++ b/src/com/redhat/ThreescaleSecurityScheme.groovy
@@ -1,0 +1,13 @@
+#!groovy
+
+package com.redhat
+
+enum ThreescaleSecurityScheme {
+  OPEN,
+  APIKEY,
+  OIDC;
+
+  // Avoid Jenkins sandbox restriction on java.util.LinkedHashMap
+  // by providing an empty constructor
+  public ThreescaleSecurityScheme() {}
+}

--- a/src/com/redhat/ThreescaleService.groovy
+++ b/src/com/redhat/ThreescaleService.groovy
@@ -3,7 +3,7 @@
 package com.redhat
 
 class ThreescaleService {
-    OpenAPI2 openapi
+    OpenAPI openapi
     List<ApplicationPlan> applicationPlans
     List<Application> applications
     ToolboxConfiguration toolbox

--- a/vars/toolbox.groovy
+++ b/vars/toolbox.groovy
@@ -25,8 +25,15 @@ ThreescaleService prepareThreescaleService(Map conf) {
     plans.add(plan)
   }
 
-
-  OpenAPI2 openapi = new OpenAPI2(conf.openapi)
+  def content = new Util().readOpenAPISpecificationFile(conf.openapi.filename)
+  OpenAPI openapi = null
+  if (content.swagger != null && content.swagger == "2.0") {
+    openapi = new OpenAPI2(conf.openapi + [ content: content ])
+  } else if (content.openapi != null && content.openapi instanceof String && content.openapi.startsWith("3.0")) {
+    openapi = new OpenAPI3(conf.openapi + [ content: content ])
+  } else {
+      throw new Exception("Cannot determine the OpenAPI version from 'openapi: ${content.openapi}' and 'swagger: ${content.swagger}'!")
+  }
   openapi.parseOpenAPISpecificationFile()
   openapi.updateTitleWithEnvironmentAndVersion(conf.environment.environmentName)
 


### PR DESCRIPTION
This PR adds support for OpenAPI 3 since it is now implemented in the 3scale toolbox.

- Added an OpenAPI super-class with two subclasses OpenAPI2 and OpenAPI3
- implements a factory in the `prepareThreescaleService` function